### PR TITLE
ci: use new conda activation procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   - MYCONDAPY=2.7
   - MYCONDAPY=3.5
   - MYCONDAPY=3.6
+  - MYCONDAPY=3.7
+
 
 ####
 # EVERYTHING BELOW THIS LINE WILL BE COPIED INTO OTHER YMLs
@@ -76,7 +78,8 @@ before_install:
 
 
 install:
-- source $HOME/miniconda/bin/activate
+- source $HOME/miniconda/etc/profile.d/conda.sh
+- conda activate
 - hash -r
 
 # Configure conda and get a few essentials

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ cache:
   - $HOME/miniconda
 
 before_cache:
-- if [[ ! $TRAVIS_TAG ]]; then rm -rf $HOME/miniconda/conda-bld; fi
-- rm -rf $HOME/miniconda/locks $HOME/miniconda/pkgs $HOME/miniconda/var $HOME/miniconda/conda-meta/history
+- conda clean --all --yes
 - conda build purge
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - MYCONDAPY=2.7
   - MYCONDAPY=3.5
   - MYCONDAPY=3.6
-  - MYCONDAPY=3.7
+  # - MYCONDAPY=3.7
 
 
 ####

--- a/README.rst
+++ b/README.rst
@@ -70,10 +70,10 @@ OMMProtocol is scientific software, funded by public research grants (Spanish MI
 .. code-block:: latex
 
     @article{ommprotocol,
-    author    = {Rodriguez-Guerra Pedregal, Jaime and
+    author    = {Rodríguez-Guerra Pedregal, Jaime and
                  Alonso-Cotchico, Lur and
                  Velasco-Carneros, Lorea and
-                 Marechal, Jean-Didier}
+                 Maréchal, Jean-Didier}
     title     = {OMMProtocol: A Command Line Application to Launch Molecular Dynamics Simulations with OpenMM},
     url       = {https://chemrxiv.org/articles/OMMProtocol_A_Command_Line_Application_to_Launch_Molecular_Dynamics_Simulations_with_OpenMM/7059263/1},
     DOI       = {10.26434/chemrxiv.7059263.v1}

--- a/README.rst
+++ b/README.rst
@@ -70,10 +70,10 @@ OMMProtocol is scientific software, funded by public research grants (Spanish MI
 .. code-block:: latex
 
     @article{ommprotocol,
-    author    = {Rodríguez-Guerra Pedregal, Jaime and
+    author    = {Rodriguez-Guerra Pedregal, Jaime and
                  Alonso-Cotchico, Lur and
                  Velasco-Carneros, Lorea and
-                 Maréchal, Jean-Didier}
+                 Marechal, Jean-Didier}
     title     = {OMMProtocol: A Command Line Application to Launch Molecular Dynamics Simulations with OpenMM},
     url       = {https://chemrxiv.org/articles/OMMProtocol_A_Command_Line_Application_to_Launch_Molecular_Dynamics_Simulations_with_OpenMM/7059263/1},
     DOI       = {10.26434/chemrxiv.7059263.v1}

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,8 +8,7 @@ about:
   summary: Easy to deploy MD protocols for OpenMM
 
 source:
-  git_url: https://github.com/insilichem/ommprotocol.git
-  git_tag: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+  path: ../../
 
 requirements:
   build:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
+from setuptools import setup, find_packages
+import io
 import os
 import versioneer
 
 VERSION = versioneer.get_version()
 
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(*filenames, **kwargs):
+    encoding = kwargs.get('encoding', 'utf-8')
+    sep = kwargs.get('sep', '\n')
+    buf = []
+    for filename in filenames:
+        with io.open(os.path.join(os.path.dirname(__file__), filename), encoding=encoding) as f:
+            buf.append(f.read())
+    return sep.join(buf)
+
+long_description = read('README.rst')
 
 setup(
     name='ommprotocol',
@@ -21,8 +30,8 @@ setup(
     author="Jaime Rodríguez-Guerra",
     author_email='jaime.rogue@gmail.com',
     description='Easy to deploy MD protocols for OpenMM',
-    long_description=read('README.rst'),
-    packages=['ommprotocol'],
+    long_description=long_description,
+    packages=find_packages(),
     package_data={'': ['../examples/*.yaml']},
     platforms='any',
     classifiers=[


### PR DESCRIPTION
Travis and AppVeyor were out of date. New `conda` use a different activation mechanism. In this PR, `.travis.yml` and `appveyor.yml` should be updated to reflect this new behaviour.