### PR TITLE
Fix: particle indexes passed to addParticle

### DIFF
--- a/ommprotocol/md.py
+++ b/ommprotocol/md.py
@@ -530,8 +530,8 @@ class Stage(object):
         positions = self.positions if self.positions is not None else self.handler.positions
         if indices is None:
             indices = range(self.handler.topology.getNumAtoms())
-        for i, index in enumerate(indices):
-            force.addParticle(i, positions[index].value_in_unit(u.nanometers))
+        for index in indices:
+            force.addParticle(int(index), positions[index].value_in_unit(nanometers))
         return force
 
     def distance_restraint_force(self, atoms, distances, strengths):

--- a/ommprotocol/md.py
+++ b/ommprotocol/md.py
@@ -531,7 +531,7 @@ class Stage(object):
         if indices is None:
             indices = range(self.handler.topology.getNumAtoms())
         for index in indices:
-            force.addParticle(int(index), positions[index].value_in_unit(nanometers))
+            force.addParticle(int(index), positions[index].value_in_unit(u.nanometers))
         return force
 
     def distance_restraint_force(self, atoms, distances, strengths):


### PR DESCRIPTION
Without this fix, it appears that the particle indexes passed to force.addParticle() in restraint_force() were incorrect when selectors are used.

I've been using this code to learn how to write my own steered MD protocol, and I ran into this part while going through it.  The first argument to addParticle() is a particle index; it should always be equal to the index used to subscript positions[index].  When calling enumerate in this way, in general, i is not the same as index.

The particle index is also expected to be an int; MDTrajTopology select() returns an ndarray of int64, which needs an explicit cast as done here.  Omitting the cast would case `NotImplementedError: Wrong number or type of arguments for overloaded function 'CustomExternalForce_addParticle'.`.

The original code appears to works correctly if no selectors are used, since in that case i and index would be equal.  But if any selectors (eg "backbone") are used, then it would add forces to the wrong particles.

I would be grateful if you can double-check this and let me know if my understanding of what is going on is correct.