### PR TITLE
Replace deprecated call to DataFrame.ix with DataFrame.iloc

### DIFF
--- a/ommprotocol/analyze.py
+++ b/ommprotocol/analyze.py
@@ -24,7 +24,7 @@ def plot_log(paths):
     import pandas as pd
     multi_csv = (pd.read_csv(path, sep="\t", index_col=1) for path in paths)
     df = pd.concat(multi_csv, ignore_index=True)
-    df.ix[:, 1:5].plot(subplots=True, layout=(2,2))
+    df.iloc[:, 1:5].plot(subplots=True, layout=(2,2))
     plt.show()
 
 


### PR DESCRIPTION
Dear developers,

ommanalyze calls the deprecated `DataFrame.ix` method at one point.

https://github.com/insilichem/ommprotocol/blob/377f4937592815e367414184787a8f69e64b9efe/ommprotocol/analyze.py#L27

This tiny PR updates this line, so ommanalyze also works with recent pandas versions (tested against pandas 1.2.4).

All the best,
Johannes